### PR TITLE
ラジオボタンを埋め込んでいたDOMの構成が変わったので追従

### DIFF
--- a/github.commitdiff.user.js
+++ b/github.commitdiff.user.js
@@ -20,7 +20,7 @@
       return {
         selector: {
           commitArea: '.commit-links-cell',
-          commitLink: 'div.BtnGroup .zeroclipboard-button:first',
+          commitLink: 'div.BtnGroup clipboard-copy.btn-outline:first',
           headerButtonArea: '.pagehead-actions',
           radioInput: 'input.commitHash',
           commitDiffButton: 'li#showDiffButton'

--- a/github.commitdiff.user.js
+++ b/github.commitdiff.user.js
@@ -3,7 +3,7 @@
 // @author         Jun Hashimoto
 // @description    Add diff link for github commit list page.
 // @include        https://github.com/*
-// @version        1.1.0
+// @version        1.1.1
 // @require        https://code.jquery.com/jquery-3.2.1.min.js
 // ==/UserScript==
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/531477/37241672-678ab77a-24a0-11e8-92b1-bf00c055d334.png)

ここの部分が `<clipboard-copy ...> ... </clipboard-copy>` になっていたので追従した。